### PR TITLE
[add] relative paths can be handled with the root directive

### DIFF
--- a/srcs/http/HttpRes.cpp
+++ b/srcs/http/HttpRes.cpp
@@ -209,6 +209,9 @@ bool HttpRes::isAllowMethod(std::string method) {
 std::string HttpRes::joinPath() {
 //    std::cout << "===== joinPath =====" << std::endl;
 	std::string path_root = target.getRoot();
+	if (path_root == "" || path_root[0] != '/') {
+		path_root = "./" + path_root;
+	}
 	std::string config_path  = target.getUri();
     std::string upload_path = target.getUploadPath();
 	std::string file_path = httpreq.getUri();


### PR DESCRIPTION
rootディレクティブで相対パス(server直下からの)を取り扱えるようにし、rootディレクティブが存在しない場合もserver直下がrootになるように変更しました。