### PR TITLE
リクエストのパース時のエラー処理周りの修正

### DIFF
--- a/srcs/http/cgi.cpp
+++ b/srcs/http/cgi.cpp
@@ -190,8 +190,6 @@ void Cgi::forkProcess() {
         return;
     }
 	if (pid == 0) {
-//		set_signal_handler(SIGINT, SIG_DFL);
-//		set_signal_handler(SIGQUIT, SIG_DFL);
 		close(fd[1]);
 		close(fd2[0]);
 
@@ -326,6 +324,9 @@ std::string Cgi::getTokenToEOL(size_t& idx) {
 			if (buf[idx+1] == '\012') {
 				idx += 2;
 				return line;
+			} else {
+				status = 400;
+				return "";
 			}
 		} else if (buf[idx] == '\012') {
 			idx++;
@@ -409,31 +410,6 @@ int Cgi::parseCgiResponse() {
     fixUp();
     return status;
 }
-
-//void	Cgi::get_exit_status(pid_t pid)
-//{
-//	int		exit_status;
-//	pid_t	pid2;
-//
-//	pid2 = 0;
-//	while (pid2 != -1)
-//	{
-//		pid2 = waitpid(-1, &exit_status, 0);
-//		if (pid == pid2)
-//		{
-//			if (WIFSIGNALED(exit_status))
-//			{
-////				if (WTERMSIG(status) == SIGQUIT)
-//                status = 502;
-////				status = WTERMSIG(status);
-////                std::cout << "exit status" << status << std::endl;
-//			}
-////			else if (WIFEXITED(exit_status))
-////				exit_status = WEXITSTATUS(exit_status);
-//		}
-//	}
-//}
-
 
 void Cgi::runCgi() {
 

--- a/srcs/http/httpReq.cpp
+++ b/srcs/http/httpReq.cpp
@@ -159,9 +159,6 @@ void httpReq::setHeaderField(const std::string& name, const std::string value)
 {
     if (name == "host" && header_fields.count("host") == 1) {
 		return rejectReq(400);
-//        setErrStatus(400);
-//		is_req_end = true;
-//        return;
     } else if (header_fields.count(name) == 1) {
         header_fields[name] += " ," + value;
     } else {
@@ -274,8 +271,6 @@ int httpReq::expect(char c)
     if (buf[idx] != c) {
         std::cerr << "no expected Error" << c << std::endl;
 		rejectReq(400);
-//        setErrStatus(400);
-//		is_req_end = true;
         return 1;
     }
     ++idx;
@@ -297,20 +292,14 @@ std::string httpReq::getToken(char delimiter)
 		std::cout << "token: " << token<< std::endl;
 		std::cout << "ko getToken" << std::endl;
 		rejectReq(400);
-//        setErrStatus(400);
-//		is_req_end = true;
         return "";
 	}
 	if (expect(delimiter)) {
 		rejectReq(400);
-//        setErrStatus(400);
-//		is_req_end = true;
         return "";
     }
     if (token.find(' ') != std::string::npos) {
 		rejectReq(400);
-//        setErrStatus(400);
-//		is_req_end = true;
         return "";
     }
 	return token;
@@ -354,8 +343,6 @@ int httpReq::getChunkSize() {
 				if (tmp == "" || tmp.find_first_not_of("0123456789abcdef") != std::string::npos) {
 					std::cerr << "400 Bad request" << std::endl;
 					rejectReq(400);
-//					setErrStatus(400);
-//					is_req_end = true;
 					return ERROR;
 				}
 				std::stringstream(tmp) >> std::hex >> chunk_size;
@@ -367,8 +354,6 @@ int httpReq::getChunkSize() {
 			} else {
 				std::cerr << "400 Bad request" << std::endl;
 				rejectReq(400);
-//				setErrStatus(400);
-//				is_req_end = true;
 				return ERROR;
 			}
 		}
@@ -475,8 +460,6 @@ void httpReq::parseScheme() {
 	} else {
         std::cerr << "invalid scheme Error" << std::endl;
 		rejectReq(400);
-//        setErrStatus(400);
-//		is_req_end = true;
 	}
 }
 
@@ -495,9 +478,6 @@ void httpReq::parseHostPort() {
     if (host.length() <= 0) {
         std::cerr << "invalid host Error" << std::endl;
 		return rejectReq(400);
-//        setErrStatus(400);
-//		is_req_end = true;
-//        return;
     }
     if (uri[i] == ':') {
         path_pos = uri.find('/');
@@ -510,18 +490,12 @@ void httpReq::parseHostPort() {
 			if (port_num < 0 || 65535 < port_num) {
         	    std::cerr << "invalid port Error" << std::endl;
 				return rejectReq(400);
-//                setErrStatus(400);
-//				is_req_end = true;
-//                return;
         	}
         }
     }
     if (uri[i] != '/') {
         std::cerr << "path not found" << std::endl;
 		return rejectReq(400);
-//        setErrStatus(400);
-//		is_req_end = true;
-//        return;
     }
     header_fields["host"] = host;
 	uri = uri.substr(i);
@@ -548,8 +522,6 @@ void httpReq::absUrlParse() {
 	    parseAuthorityAndPath();
     } else {
 		rejectReq(400);
-//        setErrStatus(400);
-//		is_req_end = true;
     }
 }
 
@@ -573,18 +545,12 @@ void httpReq::fixUp() {
 	if (header_fields.count("host") != 1) {
 		std::cerr << "no host Error" << std::endl;
 		return rejectReq(400);
-//        setErrStatus(400);
-//		is_req_end = true;
-//        return;
 	}
 
 	if (header_fields.count("connection") == 1) {
 		if (header_fields["connection"] == "") {
 			std::cerr << "no connection Error" << std::endl;
 			return rejectReq(400);
-//			setErrStatus(400);
-//			is_req_end = true;
-//			return;
 		}
 //		std::cout << "Connection field raw value: " << header_fields["connection"] << std::endl;
 		std::vector<std::string> connections = fieldValueSplit(toLower(header_fields["connection"]), ',');
@@ -610,23 +576,14 @@ void httpReq::fixUp() {
 		std::cerr << "no content-length " << std::endl;
         std::cerr << "411(Length Required)" << std::endl;
 		return rejectReq(411);
-//        setErrStatus(411);
-//		is_req_end = true;
-//        return;
 	}
     if (header_fields.count("content-length") == 1 && header_fields.count("transfer-encoding") == 1) {
         std::cerr << "400 (Bad Request)" << std::endl;
 		return rejectReq(400);
-//        setErrStatus(400);
-//		is_req_end = true;
-//        return;
     }
     if (header_fields.count("content-length") == 1) {
         if (header_fields["content-length"].find_first_not_of("0123456789") != std::string::npos) {
 			return rejectReq(400);
-//            setErrStatus(400);
-//			is_req_end = true;
-//            return;
         }
 	    std::string content_length_s = header_fields["content-length"];
         std::stringstream ss(content_length_s);
@@ -645,9 +602,6 @@ void httpReq::fixUp() {
 			if (*t_it != "chunked") {
 			    std::cerr << "501(Not Implement) transfer-encoding" << std::endl;
 				return rejectReq(501);
-//        	    setErrStatus(501);
-//				is_req_end = true;
-//        	    return;
             }
 		}
 		header_fields["transfer-encoding"] = "chunked";
@@ -656,9 +610,6 @@ void httpReq::fixUp() {
 	if (!(method == "GET" || method == "HEAD" || method == "DELETE" || method == "POST" || method == "PUT")) {
 		std::cerr << "501(Not Implement) method" << std::endl;
 		return rejectReq(501);
-//        setErrStatus(501);
-//		is_req_end = true;
-//        return;
 	}
 	if (uri.length() != 0 && uri[0] != '/') {
 		absUrlParse();
@@ -671,9 +622,6 @@ void httpReq::parseReqLine()
     if (isSpace(buf[idx])) {
         std::cerr << "status 400" << std::endl;
 		return rejectReq(400);
-//        setErrStatus(400);
-//		is_req_end = true;
-//        return;
     }
     uri = getToken(' ');
 	checkUri();
@@ -683,35 +631,23 @@ void httpReq::parseReqLine()
     if (isSpace(buf[idx])) {
         std::cerr << "status 400" << std::endl;
 		return rejectReq(400);
-//        setErrStatus(400);
-//		is_req_end = true;
-//        return;
     }
     version = buf.substr(idx, 8);
     idx += 8;
     if (version != "HTTP/1.1") { //tmp fix version
         std::cerr << "version Error" << std::endl;
 		return rejectReq(505);
-//        setErrStatus(505); //400?
-//		is_req_end = true;
-//        return;
     }
     if (buf[idx] == '\015') {
         ++idx;
         if (expect('\012')) {
 			return rejectReq(400);
-//            setErrStatus(400);
-//			is_req_end = true;
-//            return;
         }
     } else if (buf[idx] == '\012') {
         ++idx;
     } else {
         std::cerr << "invalid format" << std::endl;
 		return rejectReq(400);
-//        setErrStatus(400);
-//		is_req_end = true;
-//        return;
     }
 }
 
@@ -792,9 +728,6 @@ void httpReq::skipEmptyLines() {
 		} else {
             std::cerr << "400 (Bad Request)" << std::endl;
 			return rejectReq(400);
-//            setErrStatus(400);
-//			is_req_end = true;
-//            return;
         }
     }
 }

--- a/srcs/http/httpReq.cpp
+++ b/srcs/http/httpReq.cpp
@@ -312,6 +312,9 @@ std::string httpReq::getTokenToEOL() {
 			if (buf[idx+1] == '\012') { // expect is better
 				idx += 2;
 				return line;
+			} else {
+				rejectReq(400);
+				return "";
 			}
 		} else if (buf[idx] == '\012') {
 			idx++;

--- a/srcs/http/httpReq.hpp
+++ b/srcs/http/httpReq.hpp
@@ -105,6 +105,7 @@ class httpReq {
 		void skipTokenToEOF();
 		size_t getChunkedSize() const;
 		bool isInChunkData() const;
+		void rejectReq(int err_status); // or discardReq
 };
 
 std::ostream& operator<<(std::ostream& stream, const httpReq& obj);

--- a/srcs/send_error_test.cpp
+++ b/srcs/send_error_test.cpp
@@ -1,0 +1,79 @@
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <sys/socket.h>
+#include <arpa/inet.h>
+#include <netdb.h>
+#include <unistd.h>
+
+#define BUFFER_SIZE 1024
+
+const char *ERROR_HTTP_VERSION = "GET / HTTP/1.0\r\n"
+			"Host: localhost:8000\r\n"
+			"User-Agent: Test-Client\r\n"
+			"Accept: text/html\r\n\r\n";
+
+const char *NO_NEWLINE = "GET / HTTP/1.1\r\n"
+			"Host: localhost:8000\r"
+			"User-Agent: Test-Client\r\n"
+			"Accept: text/html\r\n\r\n";
+
+const char *NO_END_OF_HEADER = "GET / HTTP/1.1\r\n"
+			"Host: localhost:8000\r"
+			"User-Agent: Test-Client\r\n";
+
+int send_http_request(const char *host, int port, const char *request) {
+    struct sockaddr_in server_addr;
+    int sockfd, bytes_sent, bytes_received;
+    char buffer[BUFFER_SIZE];
+
+    sockfd = socket(AF_INET, SOCK_STREAM, 0);
+    if (sockfd == -1) {
+        perror("Socket creation error");
+        return -1;
+    }
+
+    memset(&server_addr, 0, sizeof(server_addr));
+    server_addr.sin_family = AF_INET;
+    server_addr.sin_port = htons(port);
+
+    if (inet_pton(AF_INET, host, &server_addr.sin_addr) <= 0) {
+        perror("Invalid address or address not supported");
+        close(sockfd);
+        return -1;
+    }
+
+    if (connect(sockfd, (struct sockaddr *)&server_addr, sizeof(server_addr)) == -1) {
+        perror("Connection error");
+        close(sockfd);
+        return -1;
+    }
+
+    bytes_sent = send(sockfd, request, strlen(request), 0);
+    if (bytes_sent == -1) {
+        perror("Send error");
+        close(sockfd);
+        return -1;
+    }
+
+    while ((bytes_received = recv(sockfd, buffer, BUFFER_SIZE - 1, 0)) > 0) {
+        buffer[bytes_received] = '\0';
+        printf("%s", buffer);
+    }
+
+    close(sockfd);
+    return 0;
+}
+
+int main() {
+    const char *host = "127.0.0.1";
+    int port = 8000;
+
+    send_http_request(host, port, ERROR_HTTP_VERSION);
+	printf("\n\n");
+    send_http_request(host, port, NO_NEWLINE);
+	printf("\n\n");
+    send_http_request(host, port, NO_END_OF_HEADER);
+
+    return 0;
+}


### PR DESCRIPTION
http versionが正しくない時のstatus codeを400から505に変更し、readRequestの使用変更に伴って、うまく機能しなくなっていたリクエストのパース時のエラーを処理してレスポンスを返せるように修正しました。