### PR TITLE
長さ制限周り

### DIFF
--- a/srcs/conf/Location.cpp
+++ b/srcs/conf/Location.cpp
@@ -3,7 +3,7 @@
 Location::Location()
 : depth(-1),
 	autoindex(false),
-	max_body_size(-1),
+	max_body_size(0),
 	which_one_exist(0)
 {}
 
@@ -77,7 +77,7 @@ void Location::setIndex(std::vector<std::string> index)
 	this->index = index;
 }
 
-void Location::setMaxBodySize(int max_body_size)
+void Location::setMaxBodySize(size_t max_body_size)
 {
 	this->max_body_size = max_body_size;
 }
@@ -158,7 +158,7 @@ std::string Location::getUploadPath() const{
 std::vector<std::string> Location::getIndex() const{
 	return index;
 }
-int Location::getMaxBodySize() const {
+size_t Location::getMaxBodySize() const {
 	return max_body_size;
 }
 

--- a/srcs/conf/Location.hpp
+++ b/srcs/conf/Location.hpp
@@ -15,7 +15,7 @@ class Location {
 		void setIsAutoindex(bool autoindex);
 		void setUploadPath(std::string upload_path);
 		void setIndex(std::vector<std::string> index);
-		void setMaxBodySize(int max_body_size);
+		void setMaxBodySize(size_t max_body_size);
 		void setCgiPath(std::string cgi_path);
 		void setReturn(std::string ret);
 		void setLocation(Location location);
@@ -33,7 +33,7 @@ class Location {
 		bool getIsAutoindex() const;
 		std::string getUploadPath() const;
         std::vector<std::string> getIndex() const;
-		int getMaxBodySize() const;
+		size_t getMaxBodySize() const;
 		std::string getCgiPath() const;
 		std::string getReturn() const;
 		std::string getErrorPage(int status_code) const;
@@ -61,7 +61,7 @@ class Location {
 		int depth;
 		std::string alias;
 		bool autoindex;
-		int max_body_size;
+		size_t max_body_size;
 		std::vector<Location> locations;
 		std::vector<std::string> cgi_ext;
         int which_one_exist;

--- a/srcs/conf/configParser.cpp
+++ b/srcs/conf/configParser.cpp
@@ -190,9 +190,9 @@ Location configParser::parseLocation() {
             }
             which_one_exist |= kMaxSizeExist;
 			std::stringstream sstream(getToken(';'));
-			int result;
+			size_t result;
 			sstream >> result;
-			if (sstream.fail() && std::numeric_limits<int>::max() == result) {
+			if (sstream.fail() && std::numeric_limits<size_t>::max() == result) {
 				std::cerr << "overflow" << std::endl;
                 throw SyntaxException("Location: invalid value: " + directive);
 			}

--- a/srcs/conf/virtualServer.cpp
+++ b/srcs/conf/virtualServer.cpp
@@ -3,7 +3,7 @@
 virtualServer::virtualServer()
 :whichOneExist(0),
 	autoindex(false),
-	max_body_size(-1)
+	max_body_size(0)
 {}
 
 virtualServer::virtualServer(const virtualServer& src)

--- a/srcs/http/HttpRes.cpp
+++ b/srcs/http/HttpRes.cpp
@@ -1321,7 +1321,7 @@ bool HttpRes::isCgi() {
 int HttpRes::checkClientBodySize() {
     if (httpreq.getContentBody() != "") {
 	    Location loc = getUri2Location(httpreq.getUri());
-        int limit_size = loc.getMaxBodySize();
+        size_t limit_size = loc.getMaxBodySize();
         if (limit_size > 0 && (limit_size < httpreq.getContentLength())) {
             status_code = REQUEST_ENTITY_TOO_LARGE;
             return status_code;

--- a/srcs/http/httpReq.cpp
+++ b/srcs/http/httpReq.cpp
@@ -486,6 +486,10 @@ void httpReq::parseHostPort() {
             std::stringstream ss(port_str);
             int port_num;
             ss >> port_num;
+			if (ss.bad()) {
+				setErrStatus(500);
+				return;
+			}
 			if (port_num < 0 || 65535 < port_num) {
         	    std::cerr << "invalid port Error" << std::endl;
                 setErrStatus(400);
@@ -594,6 +598,14 @@ void httpReq::fixUp() {
 	    std::string content_length_s = header_fields["content-length"];
         std::stringstream ss(content_length_s);
         ss >> content_length;
+		if (ss.bad()) {
+			setErrStatus(500);
+			return;
+		}
+		if (ss.fail() && (content_length == std::numeric_limits<int>::max())) {
+            setErrStatus(413); //or 400
+			return;
+		}
     }
 
     std::cout << "cl: " << content_length << std::endl;;

--- a/srcs/http/httpReq.hpp
+++ b/srcs/http/httpReq.hpp
@@ -84,6 +84,7 @@ class httpReq {
 		void skipSpace();
 		int expect(char c);
 		std::string getToken(char delimiter);
+		std::string getUriToken(char delimiter);
 		std::string getTokenToEOL();
 		void parseReqLine();
 		bool checkHeaderEnd();

--- a/srcs/http/httpReq.hpp
+++ b/srcs/http/httpReq.hpp
@@ -36,7 +36,7 @@ class httpReq {
         std::string getVersion() const;
         std::string getContentBody() const;
         std::string getBuf() const;
-        int getContentLength() const;
+        size_t getContentLength() const;
 		std::string getQueryString() const;
         std::map<std::string, std::string> getHeaderFields() const;
         int getKeepAlive() const;
@@ -75,7 +75,8 @@ class httpReq {
 		bool parse_error;
         int keep_alive;
 		std::string query_string;
-        int content_length;
+        size_t content_length;
+//        int content_length;
         int err_status;
 		size_t chunk_size;
 		bool is_in_chunk_data;


### PR DESCRIPTION
stringstreamを使ってのstringからintへの変換時のfailチェックを追加しました。
またURIの長さ制限(必要であればフィールド行、フィールド行値、ヘッダ全体の長さ制限)をどこでみるか検討中です。